### PR TITLE
Refresh site favicon

### DIFF
--- a/src/app/apple-icon.tsx
+++ b/src/app/apple-icon.tsx
@@ -11,20 +11,22 @@ export default function AppleIcon() {
     (
       <div
         style={{
-          fontSize: 100,
-          background: '#1a1a1a',
+          background: 'linear-gradient(145deg, #c4996b 0%, #a8845c 100%)',
           width: '100%',
           height: '100%',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          color: '#fff',
-          fontFamily: 'serif',
+          borderRadius: '42px',
+          color: '#f8f7f5',
+          fontFamily: 'Georgia, serif',
+          fontSize: 148,
           fontWeight: 400,
-          letterSpacing: '-0.02em',
+          letterSpacing: '-0.12em',
+          paddingRight: '14px',
         }}
       >
-        MS
+        M
       </div>
     ),
     {

--- a/src/app/icon.tsx
+++ b/src/app/icon.tsx
@@ -11,20 +11,22 @@ export default function Icon() {
     (
       <div
         style={{
-          fontSize: 20,
-          background: '#1a1a1a',
+          background: 'linear-gradient(145deg, #c4996b 0%, #a8845c 100%)',
           width: '100%',
           height: '100%',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          color: '#fff',
-          fontFamily: 'serif',
+          borderRadius: '7px',
+          color: '#f8f7f5',
+          fontFamily: 'Georgia, serif',
+          fontSize: 27,
           fontWeight: 400,
-          letterSpacing: '-0.02em',
+          letterSpacing: '-0.12em',
+          paddingRight: '3px',
         }}
       >
-        MS
+        M
       </div>
     ),
     {


### PR DESCRIPTION
## Summary
- replace the generic favicon with a warm amber Michelle monogram
- match the Apple touch icon to the updated visual system

## Verification
- `yarn lint src/app/icon.tsx src/app/apple-icon.tsx`
- `RESEND_API_KEY=re_dummy yarn build`
- verified the generated `/icon` and `/apple-icon` PNG routes