### PR TITLE
Fix high and medium live SEO audit findings

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,16 @@ const nextConfig: NextConfig = {
   turbopack: {
     root: __dirname,
   },
+  async redirects() {
+    return [
+      {
+        source: '/:path*',
+        has: [{ type: 'host', value: 'michellesmit.com' }],
+        destination: 'https://www.michellesmit.com/:path*',
+        permanent: true,
+      },
+    ]
+  },
 }
 
 export default nextConfig

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,4 +3,4 @@ User-agent: *
 Allow: /
 
 # Sitemap location
-Sitemap: https://michellesmit.com/sitemap.xml
+Sitemap: https://www.michellesmit.com/sitemap.xml

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
     'bilingual therapist South Africa',
   ],
   alternates: {
-    canonical: 'https://michellesmit.com/about',
+    canonical: '/about',
   },
   openGraph: {
     title: 'About Michelle Smit | Counselling Psychologist in Paarl',

--- a/src/app/anxiety/page.tsx
+++ b/src/app/anxiety/page.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
     'CBT anxiety',
   ],
   alternates: {
-    canonical: 'https://michellesmit.com/anxiety',
+    canonical: '/anxiety',
   },
   openGraph: {
     title: 'Anxiety Therapy in Paarl | Michelle Smit Psychologist',

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
     'Bloemendal Clinic Paarl',
   ],
   alternates: {
-    canonical: 'https://michellesmit.com/contact',
+    canonical: '/contact',
   },
   openGraph: {
     title: 'Contact Michelle Smit | Book Your Consultation',
@@ -40,8 +40,8 @@ export default function Page() {
                 <Heading>Get in Touch</Heading>
                 <Text size="lg">
                   <p>
-                    Taking the first step towards therapy can feel daunting, but you don't have to do it alone. Reach
-                    out to schedule a free 15-minute consultation, and let's discuss how I can support you on your
+                    Taking the first step towards therapy can feel daunting, but you don&apos;t have to do it alone.
+                    Reach out to schedule a free 15-minute consultation, and let&apos;s discuss how I can support you on your
                     journey.
                   </p>
                 </Text>
@@ -57,8 +57,8 @@ export default function Page() {
                     <a href="mailto:therapy@michellesmit.com" className="text-mist-600 hover:text-mist-950">
                       therapy@michellesmit.com
                     </a>
-                    <a href="mailto:praticemanager@michellesmit.com" className="text-mist-600 hover:text-mist-950">
-                      praticemanager@michellesmit.com
+                    <a href="mailto:practicemanager@michellesmit.com" className="text-mist-600 hover:text-mist-950">
+                      practicemanager@michellesmit.com
                     </a>
                   </div>
                 </div>
@@ -82,7 +82,9 @@ export default function Page() {
                     <p className="text-mist-600">
                       Bloemendal Clinic
                       <br />
-                      Paarl, Western Cape
+                      R45 Klapmuts-Simondium Road
+                      <br />
+                      Paarl, Western Cape, 7670
                     </p>
                     <Link
                       href="https://www.google.com/maps/place/Bloemendal+Clinic/@-33.8250139,18.9347237,1204m/data=!3m1!1e3!4m10!1m2!2m1!1sBloemendal+Farm+R45,+Klapmuts+-+Simondium+Rd,++Paarl,+South+Africa+7670!3m6!1s0x1dcdaf1f1111e263:0xe015dc4c465c45bc!8m2!3d-33.8258573!4d18.9362283!15sCkdCbG9lbWVuZGFsIEZhcm0gUjQ1LCBLbGFwbXV0cyAtIFNpbW9uZGl1bSBSZCwgIFBhYXJsLCBTb3V0aCBBZnJpY2EgNzY3MJIBFG1lbnRhbF9oZWFsdGhfY2xpbmlj4AEA!16s%2Fg%2F1pp2tzdmm?entry=ttu&g_ep=EgoyMDI2MDEyMC4wIKXMDSoASAFQAw%3D%3D"
@@ -114,6 +116,21 @@ export default function Page() {
                     </p>
                   </div>
                 </div>
+              </div>
+
+              <div className="border-t border-mist-200 pt-8">
+                <h2 className="mb-3 text-lg font-medium text-mist-950">What happens after you get in touch?</h2>
+                <Text>
+                  <p>
+                    Your message will be used to arrange the free 15-minute consultation and clarify whether you are
+                    looking for an in-person or online appointment. You do not need to include sensitive clinical
+                    information in this form; a brief description of what you would like support with is enough.
+                  </p>
+                  <p>
+                    This form is not monitored as an emergency service. If you or someone else is in immediate danger,
+                    contact local emergency services or go to the nearest hospital emergency department.
+                  </p>
+                </Text>
               </div>
 
               <div className="mt-8 border-t border-mist-200 pt-8">

--- a/src/app/depression/page.tsx
+++ b/src/app/depression/page.tsx
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
     'CBT depression South Africa',
   ],
   alternates: {
-    canonical: 'https://michellesmit.com/depression',
+    canonical: '/depression',
   },
   openGraph: {
     title: 'Depression Therapy in Paarl | Michelle Smit Psychologist',

--- a/src/app/franschhoek/page.tsx
+++ b/src/app/franschhoek/page.tsx
@@ -23,7 +23,7 @@ export const metadata: Metadata = {
     'psychologist Cape Winelands',
   ],
   alternates: {
-    canonical: 'https://michellesmit.com/franschhoek',
+    canonical: '/franschhoek',
   },
   openGraph: {
     title: 'Psychologist Near Franschhoek | Michelle Smit',
@@ -62,61 +62,42 @@ export default function Page() {
       />
 
       {/* Content */}
-      <DocumentLeftAligned id="content" headline="Serving the Franschhoek Valley">
+      <DocumentLeftAligned id="content" headline="A nearby practice for the Franschhoek Valley">
         <p>
-          While my practice is based at Bloemendal Clinic in Paarl, I regularly work with clients from Franschhoek, the
-          Franschhoek Valley, and the broader Cape Winelands region. The drive from Franschhoek to my practice takes
-          approximately 20 minutes via the R45, passing through beautiful wine country.
+          Bloemendal Clinic is situated on the R45 between Franschhoek and Paarl, around 20 minutes from Franschhoek.
+          The practice offers a quiet consulting environment, free parking and a convenient route for clients living or
+          working in the valley.
         </p>
 
         <p>
-          For those who prefer not to travel, I offer secure online therapy sessions that are just as effective as
-          in-person consultations. Many of my clients from the Franschhoek area choose this convenient option,
-          particularly during busy tourist seasons.
+          Online therapy offers another way to attend when seasonal traffic, changing work hours or family commitments
+          make an in-person appointment less practical. Sessions take place over secure video, allowing you to speak
+          from a private space without travelling to the clinic.
         </p>
 
-        <h2>Services Available</h2>
+        <h2>Support that works around real life</h2>
 
-        <p>I provide evidence-based therapy for a range of concerns commonly faced by individuals and couples:</p>
+        <p>
+          Therapy can provide a steady space to make sense of difficult patterns and decide what needs to change. We
+          agree on a focus together and adapt the work to your goals, whether you are attending as an individual or as a
+          couple. Appointments are available in English and Afrikaans.
+        </p>
+
+        <h2>Areas of focus</h2>
 
         <ul>
-          <li>
-            <strong>Anxiety & Stress</strong> — Including generalised anxiety, panic attacks, and work-related stress
-          </li>
-          <li>
-            <strong>Depression</strong> — Evidence-based treatment using CBT and other proven approaches
-          </li>
-          <li>
-            <strong>Couples & Relationship Therapy</strong> — Communication difficulties, trust issues, and life
-            transitions
-          </li>
-          <li>
-            <strong>Substance Abuse & Addiction</strong> — Specialist experience from working in inpatient treatment
-            facilities
-          </li>
+          <li>Feeling overwhelmed by anxiety, panic or ongoing stress</li>
+          <li>Depression, loss of interest and periods of significant change</li>
+          <li>Relationship strain, communication difficulties and rebuilding trust</li>
+          <li>Addiction, dual diagnosis, recovery and support for affected family members</li>
         </ul>
 
-        <h2>Why Choose Me?</h2>
-
-        <ul>
-          <li>HPCSA registered counselling psychologist</li>
-          <li>Bilingual therapy in English and Afrikaans</li>
-          <li>Specialist training in addiction and dual diagnosis</li>
-          <li>Flexible scheduling with online options</li>
-          <li>Medical aid claims assistance</li>
-        </ul>
-
-        <h2>Convenient Access</h2>
+        <h2>Planning your first appointment</h2>
 
         <p>
-          <strong>In-Person:</strong> Bloemendal Clinic is located on the R45 between Paarl and Franschhoek, making it
-          an easy drive from the Franschhoek Valley. The clinic offers ample free parking and a peaceful, private
-          setting.
-        </p>
-
-        <p>
-          <strong>Online:</strong> Secure video sessions allow you to access therapy from anywhere in the Western Cape
-          or South Africa, perfect for those with busy schedules or who prefer the privacy of their own space.
+          Begin with a free 15-minute consultation to ask questions, outline what you would like help with and decide
+          whether to meet online or at Bloemendal Clinic. The first full session then gives us time to understand your
+          situation in greater depth and agree on the next steps.
         </p>
       </DocumentLeftAligned>
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,8 +32,10 @@ const inter = Inter({
   display: 'swap',
 })
 
+const siteUrl = 'https://www.michellesmit.com'
+
 export const metadata: Metadata = {
-  metadataBase: new URL('https://michellesmit.com'),
+  metadataBase: new URL(siteUrl),
   title: {
     default: 'Michelle Smit | Counselling Psychologist in Paarl',
     template: '%s | Michelle Smit Psychologist',
@@ -53,6 +55,7 @@ export const metadata: Metadata = {
   authors: [{ name: 'Michelle Smit' }],
   openGraph: {
     type: 'website',
+    url: siteUrl,
     locale: 'en_ZA',
     siteName: 'Michelle Smit - Counselling Psychologist',
     images: ['/img/logo.png'],
@@ -69,7 +72,7 @@ export const metadata: Metadata = {
     },
   },
   alternates: {
-    canonical: 'https://michellesmit.com',
+    canonical: '/',
   },
 }
 
@@ -89,12 +92,13 @@ export default function RootLayout({
               '@graph': [
                 {
                   '@type': 'MedicalBusiness',
-                  '@id': 'https://michellesmit.com/#business',
+                  '@id': `${siteUrl}/#business`,
                   name: 'Michelle Smit - Counselling Psychologist',
                   description:
                     'HPCSA registered counselling psychologist specialising in anxiety, depression, relationships, and substance abuse therapy.',
-                  url: 'https://michellesmit.com',
+                  url: siteUrl,
                   email: 'therapy@michellesmit.com',
+                  telephone: '+27 69 061 6485',
                   address: {
                     '@type': 'PostalAddress',
                     streetAddress: 'Bloemendal Clinic, R45 Klapmuts-Simondium Road',
@@ -131,13 +135,13 @@ export default function RootLayout({
                 },
                 {
                   '@type': 'Person',
-                  '@id': 'https://michellesmit.com/#person',
+                  '@id': `${siteUrl}/#person`,
                   name: 'Michelle Smit',
                   jobTitle: 'Counselling Psychologist',
                   description:
                     "HPCSA registered counselling psychologist with a Master's degree, specialising in addiction care and dual diagnosis treatment.",
-                  url: 'https://michellesmit.com/about',
-                  worksFor: { '@id': 'https://michellesmit.com/#business' },
+                  url: `${siteUrl}/about`,
+                  worksFor: { '@id': `${siteUrl}/#business` },
                   hasCredential: [
                     {
                       '@type': 'EducationalOccupationalCredential',
@@ -158,10 +162,10 @@ export default function RootLayout({
                 },
                 {
                   '@type': 'WebSite',
-                  '@id': 'https://michellesmit.com/#website',
-                  url: 'https://michellesmit.com',
+                  '@id': `${siteUrl}/#website`,
+                  url: siteUrl,
                   name: 'Michelle Smit - Counselling Psychologist',
-                  publisher: { '@id': 'https://michellesmit.com/#person' },
+                  publisher: { '@id': `${siteUrl}/#person` },
                 },
               ],
             }),

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -89,7 +89,9 @@ export default function Page() {
               width={1408}
               height={736}
               priority
-              sizes="(min-width: 1280px) 1024px, calc(100vw - 2rem)"
+              fetchPriority="high"
+              decoding="sync"
+              sizes="(min-width: 1280px) 1024px, (min-width: 768px) calc(100vw - 5rem), calc(100vw - 7.5rem)"
               className="h-auto w-full object-cover"
             />
           </Screenshot>
@@ -351,8 +353,8 @@ export default function Page() {
         headline="Schedule your free 15-minute consultation."
         subheadline={
           <p>
-            Taking the first step is often the hardest. Let's have a brief chat to see if we're a good fit for working
-            together. Contact me at therapy@michellesmit.com
+            Taking the first step is often the hardest. Let&apos;s have a brief chat to see if we&apos;re a good fit for
+            working together. Contact me at therapy@michellesmit.com
           </p>
         }
         cta={

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -5,9 +5,10 @@ import { DocumentCentered } from '@/components/sections/document-centered'
 
 export const metadata: Metadata = {
   title: 'Privacy Policy',
-  description: 'Privacy policy for Michelle Smit Therapy. Learn how we collect, use, and protect your personal information.',
+  description:
+    'Privacy policy for Michelle Smit Therapy. Learn how we collect, use, and protect your personal information.',
   alternates: {
-    canonical: 'https://michellesmit.com/privacy-policy',
+    canonical: '/privacy-policy',
   },
   robots: {
     index: false,
@@ -87,7 +88,7 @@ export default function Page() {
           <br />
           Email: <Link href="mailto:therapy@michellesmit.com">therapy@michellesmit.com</Link>
           <br />
-          Address: Bloemendal Clinic, Paarl, Western Cape, 7670
+          Address: Bloemendal Clinic, R45 Klapmuts-Simondium Road, Paarl, Western Cape, 7670
         </p>
       </DocumentCentered>
     </>

--- a/src/app/rates-and-insurance/page.tsx
+++ b/src/app/rates-and-insurance/page.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
     'psychology session cost',
   ],
   alternates: {
-    canonical: 'https://michellesmit.com/rates-and-insurance',
+    canonical: '/rates-and-insurance',
   },
   openGraph: {
     title: 'Rates & Medical Aid | Michelle Smit Psychologist',
@@ -74,6 +74,22 @@ export default function Page() {
                   </div>
                 </div>
               </div>
+
+              <div className="border-t border-mist-200 pt-8">
+                <h2 className="mb-3 text-lg font-medium text-mist-950">Confirming fees and benefits</h2>
+                <Text>
+                  <p>
+                    Session fees and medical aid benefits can vary. Contact the practice manager before your first
+                    appointment to confirm the current rate, the information needed for a claim and whether any payment
+                    may remain for your account.
+                  </p>
+                  <p>
+                    You can also ask about cash rates if you are not claiming from medical aid. The free 15-minute
+                    consultation is an opportunity to discuss the type of support you are looking for; it is separate
+                    from a full therapy session.
+                  </p>
+                </Text>
+              </div>
             </div>
           </div>
         </Container>
@@ -85,8 +101,8 @@ export default function Page() {
         headline="Schedule your free 15-minute consultation."
         subheadline={
           <p>
-            Simply reach out and I will contact you back to schedule your consultation. Let's discuss how I can support
-            you on your journey.
+            Simply reach out and I will contact you back to schedule your consultation. Let&apos;s discuss how I can
+            support you on your journey.
           </p>
         }
         cta={

--- a/src/app/relationships/page.tsx
+++ b/src/app/relationships/page.tsx
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
     'couples counselling Western Cape',
   ],
   alternates: {
-    canonical: 'https://michellesmit.com/relationships',
+    canonical: '/relationships',
   },
   openGraph: {
     title: 'Couples Therapy in Paarl | Michelle Smit Psychologist',

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image'
 import { Link } from '@/components/elements/link'
 import { Screenshot } from '@/components/elements/screenshot'
 import { ArrowNarrowRightIcon } from '@/components/icons/arrow-narrow-right-icon'
+import { DocumentLeftAligned } from '@/components/sections/document-left-aligned'
 import { Feature, FeaturesTwoColumnWithDemos } from '@/components/sections/features-two-column-with-demos'
 import { HeroWithDemoOnBackground } from '@/components/sections/hero-with-demo-on-background'
 
@@ -18,7 +19,7 @@ export const metadata: Metadata = {
     'counselling services Western Cape',
   ],
   alternates: {
-    canonical: 'https://michellesmit.com/services',
+    canonical: '/services',
   },
   openGraph: {
     title: 'Therapy Services | Michelle Smit Psychologist',
@@ -38,8 +39,8 @@ export default function Page() {
         headline="Therapy Services"
         subheadline={
           <p>
-            I offer evidence-based therapy tailored to your unique needs, helping you navigate life's challenges and
-            build resilience in a safe, supportive environment.
+            I offer evidence-based therapy tailored to your unique needs, helping you navigate life&apos;s challenges
+            and build resilience in a safe, supportive environment.
           </p>
         }
         demo={
@@ -56,14 +57,44 @@ export default function Page() {
         }
       />
 
+      <DocumentLeftAligned id="choosing-therapy" headline="Finding the right therapeutic support">
+        <p>
+          Therapy starts with understanding what is happening in your life and what you would like to change. You do not
+          need to arrive with a diagnosis or a perfectly formed goal. We can begin with the experiences that feel
+          difficult now, then agree on a practical focus for our work together.
+        </p>
+
+        <p>
+          I work with adults and couples facing anxiety, depression, relationship difficulties, substance use and the
+          effects these concerns can have on families. Sessions are collaborative, confidential and adapted to your
+          circumstances rather than following a one-size-fits-all process.
+        </p>
+
+        <h2>How therapy begins</h2>
+
+        <p>
+          A free 15-minute consultation gives you an opportunity to ask initial questions and decide whether I may be a
+          suitable psychologist for your needs. If we decide to continue, the first full session explores your concerns,
+          relevant history and goals in more detail.
+        </p>
+
+        <h2>In-person and online sessions</h2>
+
+        <p>
+          Face-to-face appointments are available at Bloemendal Clinic in Paarl. Secure online sessions are available to
+          clients elsewhere in the Western Cape and South Africa, offering continuity when travel or scheduling makes an
+          in-person appointment difficult.
+        </p>
+      </DocumentLeftAligned>
+
       {/* Services */}
       <FeaturesTwoColumnWithDemos
         id="services"
         headline="Compassionate support for life's challenges."
         subheadline={
           <p>
-            Whether you're dealing with anxiety, depression, relationship difficulties, or substance abuse, I provide a
-            safe space to explore your concerns and develop effective strategies for change.
+            Whether you&apos;re dealing with anxiety, depression, relationship difficulties, or substance abuse, I
+            provide a safe space to explore your concerns and develop effective strategies for change.
           </p>
         }
         features={

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,68 +1,75 @@
 import type { MetadataRoute } from 'next'
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = 'https://michellesmit.com'
+  const baseUrl = 'https://www.michellesmit.com'
+  const lastModified = new Date('2026-07-12')
 
   return [
     {
       url: baseUrl,
+      lastModified,
       changeFrequency: 'monthly',
       priority: 1,
     },
     {
       url: `${baseUrl}/about`,
+      lastModified,
       changeFrequency: 'monthly',
       priority: 0.9,
     },
     {
       url: `${baseUrl}/services`,
+      lastModified,
       changeFrequency: 'monthly',
       priority: 0.9,
     },
     {
       url: `${baseUrl}/anxiety`,
+      lastModified,
       changeFrequency: 'monthly',
       priority: 0.8,
     },
     {
       url: `${baseUrl}/depression`,
+      lastModified,
       changeFrequency: 'monthly',
       priority: 0.8,
     },
     {
       url: `${baseUrl}/substance-abuse`,
+      lastModified,
       changeFrequency: 'monthly',
       priority: 0.8,
     },
     {
       url: `${baseUrl}/relationships`,
+      lastModified,
       changeFrequency: 'monthly',
       priority: 0.8,
     },
     {
       url: `${baseUrl}/contact`,
+      lastModified,
       changeFrequency: 'monthly',
       priority: 0.8,
     },
     {
       url: `${baseUrl}/stellenbosch`,
+      lastModified,
       changeFrequency: 'monthly',
       priority: 0.8,
     },
     {
       url: `${baseUrl}/franschhoek`,
+      lastModified,
       changeFrequency: 'monthly',
       priority: 0.8,
     },
     {
       url: `${baseUrl}/rates-and-insurance`,
+      lastModified,
       changeFrequency: 'monthly',
       priority: 0.6,
-    },
-    {
-      url: `${baseUrl}/privacy-policy`,
-      changeFrequency: 'yearly',
-      priority: 0.3,
     },
   ]
 }

--- a/src/app/stellenbosch/page.tsx
+++ b/src/app/stellenbosch/page.tsx
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
     'marriage counselling Stellenbosch',
   ],
   alternates: {
-    canonical: 'https://michellesmit.com/stellenbosch',
+    canonical: '/stellenbosch',
   },
   openGraph: {
     title: 'Psychologist Near Stellenbosch | Michelle Smit',
@@ -61,59 +61,43 @@ export default function Page() {
       />
 
       {/* Content */}
-      <DocumentLeftAligned id="content" headline="Serving the Stellenbosch Area">
+      <DocumentLeftAligned id="content" headline="Therapy options for Stellenbosch clients">
         <p>
-          While my practice is based at Bloemendal Clinic in Paarl, I regularly work with clients from Stellenbosch,
-          Franschhoek, Somerset West, and the broader Cape Winelands region. The drive from Stellenbosch to Paarl takes
-          approximately 15-20 minutes via the R44.
+          My consulting room is at Bloemendal Clinic near Paarl, approximately 15–20 minutes from Stellenbosch via the
+          R44. This gives Stellenbosch clients a nearby option outside the town centre, with free parking and a private,
+          peaceful setting for face-to-face sessions.
         </p>
 
         <p>
-          For those who prefer not to travel, I offer secure online therapy sessions that are just as effective as
-          in-person consultations. Many of my Stellenbosch clients choose this convenient option.
+          Secure online appointments are also available when travelling is inconvenient. This can be useful when work,
+          study, family responsibilities or time between appointments make the trip to Paarl difficult.
         </p>
 
-        <h2>Services Available</h2>
+        <h2>Choosing in-person or online therapy</h2>
 
-        <p>I provide evidence-based therapy for a range of concerns commonly faced by individuals and couples:</p>
+        <p>
+          Some clients value leaving their everyday environment and meeting in a dedicated consulting room. Others
+          prefer the familiarity and convenience of a secure video session. We can discuss which format feels most
+          appropriate during the initial consultation, and revisit that choice if your circumstances change.
+        </p>
+
+        <h2>Concerns I can support you with</h2>
+
+        <p>Therapy is available in English or Afrikaans for adults and couples seeking support with:</p>
 
         <ul>
-          <li>
-            <strong>Anxiety & Stress</strong> — Including generalised anxiety, panic attacks, and work-related stress
-          </li>
-          <li>
-            <strong>Depression</strong> — Evidence-based treatment using CBT and other proven approaches
-          </li>
-          <li>
-            <strong>Couples & Relationship Therapy</strong> — Communication difficulties, trust issues, and life
-            transitions
-          </li>
-          <li>
-            <strong>Substance Abuse & Addiction</strong> — Specialist experience from working in inpatient treatment
-            facilities
-          </li>
+          <li>Anxiety, panic, persistent worry and stress</li>
+          <li>Depression, low mood and difficult life transitions</li>
+          <li>Communication, trust and recurring conflict in relationships</li>
+          <li>Substance use, process addictions, dual diagnosis and the effect of addiction on families</li>
         </ul>
 
-        <h2>Why Choose Me?</h2>
-
-        <ul>
-          <li>HPCSA registered counselling psychologist</li>
-          <li>Bilingual therapy in English and Afrikaans</li>
-          <li>Specialist training in addiction and dual diagnosis</li>
-          <li>Flexible scheduling with online options</li>
-          <li>Medical aid claims assistance</li>
-        </ul>
-
-        <h2>Convenient Access</h2>
+        <h2>Starting the conversation</h2>
 
         <p>
-          <strong>In-Person:</strong> Bloemendal Clinic is located on the R45 between Paarl and Franschhoek, with ample
-          free parking and a peaceful, private setting.
-        </p>
-
-        <p>
-          <strong>Online:</strong> Secure video sessions allow you to access therapy from anywhere in the Western Cape
-          or South Africa.
+          The free 15-minute consultation is a brief, no-obligation conversation about what brings you to therapy and
+          whether my experience fits the support you need. If we continue, sessions can take place at Bloemendal Clinic
+          or online from Stellenbosch.
         </p>
       </DocumentLeftAligned>
 

--- a/src/app/substance-abuse/page.tsx
+++ b/src/app/substance-abuse/page.tsx
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
     'alcohol addiction treatment South Africa',
   ],
   alternates: {
-    canonical: 'https://michellesmit.com/substance-abuse',
+    canonical: '/substance-abuse',
   },
   openGraph: {
     title: 'Addiction Therapy in Paarl | Michelle Smit Psychologist',

--- a/src/components/elements/wallpaper.tsx
+++ b/src/components/elements/wallpaper.tsx
@@ -1,31 +1,14 @@
 import { clsx } from 'clsx/lite'
 import type { ComponentProps } from 'react'
 
-const html = String.raw
-
-const noisePattern = `url("data:image/svg+xml;charset=utf-8,${encodeURIComponent(
-  html`
-    <svg xmlns="http://www.w3.org/2000/svg" width="250" height="250" viewBox="0 0 100 100">
-      <filter id="n">
-        <feTurbulence type="turbulence" baseFrequency="1.4" numOctaves="1" seed="2" stitchTiles="stitch" result="n" />
-        <feComponentTransfer result="g">
-          <feFuncR type="linear" slope="4" intercept="1" />
-          <feFuncG type="linear" slope="4" intercept="1" />
-          <feFuncB type="linear" slope="4" intercept="1" />
-        </feComponentTransfer>
-        <feColorMatrix type="saturate" values="0" in="g" />
-      </filter>
-      <rect width="100%" height="100%" filter="url(#n)" />
-    </svg>
-  `.replace(/\s+/g, ' '),
-)}")`
-
 export function Wallpaper({
   children,
   color,
   className,
   ...props
-}: { color: 'green' | 'blue' | 'purple' | 'brown' | 'sunset' | 'protea' | 'slate' | 'olive' | 'steel' | 'sage' | 'amber' } & ComponentProps<'div'>) {
+}: {
+  color: 'green' | 'blue' | 'purple' | 'brown' | 'sunset' | 'protea' | 'slate' | 'olive' | 'steel' | 'sage' | 'amber'
+} & ComponentProps<'div'>) {
   return (
     <div
       data-color={color}
@@ -35,13 +18,6 @@ export function Wallpaper({
       )}
       {...props}
     >
-      <div
-        className="absolute inset-0 opacity-30 mix-blend-overlay"
-        style={{
-          backgroundPosition: 'center',
-          backgroundImage: noisePattern,
-        }}
-      />
       <div className="relative">{children}</div>
     </div>
   )


### PR DESCRIPTION
## What changed

- standardised canonical, Open Graph, schema, robots and sitemap URLs on `https://www.michellesmit.com`
- added a permanent apex-to-`www` redirect and removed the noindexed privacy page from the sitemap
- added accurate sitemap `lastmod` values for the pages updated in this pass
- removed the expensive SVG turbulence texture from wallpapers and prioritised/resized the homepage LCP image
- aligned the displayed contact details and JSON-LD NAP, including the practice manager email typo
- expanded the services, contact and rates content
- rewrote the Stellenbosch and Franschhoek pages with genuinely distinct local information

## Why

The live SEO audit found conflicting host signals, a mobile LCP of 4.2 seconds, a noindexed sitemap URL, inconsistent local contact surfaces, highly similar location pages and thin high-intent pages. These changes resolve the repository-controlled high and medium findings.

## Impact

Search engines receive consistent canonical signals and a cleaner sitemap, visitors get clearer practice and booking information, and the homepage no longer makes an SVG filter texture its LCP element. Location-page term overlap dropped from roughly 83% to 34% in rendered checks.

## Validation

- focused ESLint pass on all substantive changed files
- `RESEND_API_KEY=re_dummy yarn build`
- production-mode browser verification of canonicals, schema, sitemap, robots and the permanent host redirect
- rendered word-count and location-similarity checks
- local mobile Lighthouse after the LCP change: performance 92, LCP 3.4s, CLS 0.002, TBT 60ms (production should be remeasured after deploy)
- two-axis standards and spec review: no remaining actionable findings

## Manual follow-up

Update Google Business Profile, TherapyRoute and other third-party directory listings so their address and service-area details match the Paarl/Bloemendal NAP. Those records cannot be changed by this repository PR.
