### PR TITLE
Fix portrait alignment, mobile menu behavior, and hero spacing

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -39,6 +39,7 @@ export default function Page() {
       <HeroWithDemoOnBackground
         id="hero"
         color="green"
+        demoAlignment="right"
         headline="Michelle Smit"
         subheadline={
           <p>

--- a/src/components/sections/call-to-action-simple.tsx
+++ b/src/components/sections/call-to-action-simple.tsx
@@ -32,7 +32,7 @@ export function CallToActionSimple({
                 alt={image.alt}
                 fill
                 sizes="(min-width: 640px) 10rem, 100vw"
-                className="object-cover"
+                className="object-cover object-[center_20%] sm:object-center"
               />
             </div>
           )}

--- a/src/components/sections/hero-with-demo-on-background.tsx
+++ b/src/components/sections/hero-with-demo-on-background.tsx
@@ -43,7 +43,7 @@ export function HeroWithDemoOnBackground({
                 <div className="relative h-72 sm:h-92 md:h-125 lg:size-full">
                   <div
                     className={clsx(
-                      'absolute inset-y-0 flex w-screen overflow-hidden *:h-full *:w-auto *:max-w-none max-lg:rounded-t-lg',
+                      'absolute inset-y-0 flex w-screen overflow-hidden *:h-full *:w-auto *:max-w-none *:rounded-t-lg max-lg:rounded-t-lg',
                       demoAlignment === 'right' ? 'right-0 justify-end lg:rounded-tr-lg' : 'left-0 lg:rounded-tl-lg',
                     )}
                   >

--- a/src/components/sections/hero-with-demo-on-background.tsx
+++ b/src/components/sections/hero-with-demo-on-background.tsx
@@ -10,6 +10,7 @@ export function HeroWithDemoOnBackground({
   subheadline,
   cta,
   demo,
+  demoAlignment = 'left',
   footer,
   color = 'blue',
   className,
@@ -20,6 +21,7 @@ export function HeroWithDemoOnBackground({
   subheadline: ReactNode
   cta?: ReactNode
   demo?: ReactNode
+  demoAlignment?: 'left' | 'right'
   footer?: ReactNode
   color?: 'green' | 'blue' | 'purple' | 'brown' | 'sunset' | 'protea'
 } & ComponentProps<'section'>) {
@@ -37,9 +39,14 @@ export function HeroWithDemoOnBackground({
                 <div className="flex max-w-3xl flex-col gap-4 text-lg/8 text-white/70">{subheadline}</div>
                 {cta}
               </div>
-              <div className="lg:pt-24">
+              <div className="lg:min-w-0 lg:flex-1 lg:pt-24">
                 <div className="relative h-72 sm:h-92 md:h-125 lg:size-full">
-                  <div className="absolute inset-y-0 left-0 flex w-screen overflow-hidden *:h-full *:w-auto *:max-w-none max-lg:rounded-t-lg lg:rounded-tl-lg">
+                  <div
+                    className={clsx(
+                      'absolute inset-y-0 flex w-screen overflow-hidden *:h-full *:w-auto *:max-w-none max-lg:rounded-t-lg',
+                      demoAlignment === 'right' ? 'right-0 justify-end lg:rounded-tr-lg' : 'left-0 lg:rounded-tl-lg',
+                    )}
+                  >
                     {demo}
                   </div>
                 </div>

--- a/src/components/sections/hero-with-demo-on-background.tsx
+++ b/src/components/sections/hero-with-demo-on-background.tsx
@@ -24,7 +24,7 @@ export function HeroWithDemoOnBackground({
   color?: 'green' | 'blue' | 'purple' | 'brown' | 'sunset' | 'protea'
 } & ComponentProps<'section'>) {
   return (
-    <section className={clsx('flex flex-col gap-16 px-2 pb-16', className)} {...props}>
+    <section className={clsx('flex flex-col gap-16 px-2 sm:pb-16', className)} {...props}>
       <Wallpaper className="rounded-lg" color={color}>
         <div className="-mx-2 sm:px-6 md:px-12 lg:px-0">
           <Container className="flex flex-col gap-16">
@@ -48,7 +48,7 @@ export function HeroWithDemoOnBackground({
           </Container>
         </div>
       </Wallpaper>
-      <Container>{footer}</Container>
+      {footer && <Container>{footer}</Container>}
     </section>
   )
 }

--- a/src/components/sections/navbar-with-links-actions-and-centered-logo.tsx
+++ b/src/components/sections/navbar-with-links-actions-and-centered-logo.tsx
@@ -1,18 +1,37 @@
+'use client'
+
 import Link from 'next/link'
 
 import { ElDialog, ElDialogPanel } from '@tailwindplus/elements/react'
 import { clsx } from 'clsx/lite'
-import type { ComponentProps, ReactNode } from 'react'
+import type { ComponentProps, MouseEvent, ReactNode } from 'react'
 
 export function NavbarLink({
   children,
   href,
   className,
+  onClick,
   ...props
 }: { href: string } & Omit<ComponentProps<'a'>, 'href'>) {
+  function handleClick(event: MouseEvent<HTMLAnchorElement>) {
+    onClick?.(event)
+
+    if (event.defaultPrevented) {
+      return
+    }
+
+    const dialog = event.currentTarget.closest('dialog')
+
+    if (dialog instanceof HTMLDialogElement) {
+      dialog.close()
+      window.scrollTo({ top: 0, left: 0, behavior: 'auto' })
+    }
+  }
+
   return (
     <Link
       href={href}
+      onClick={handleClick}
       className={clsx(
         'group inline-flex items-center justify-between gap-2 text-3xl/10 font-medium text-mist-950 lg:text-sm/7',
         className,


### PR DESCRIPTION
## Summary

- keep Michelle’s face and full head in frame in the shared mobile consultation CTA
- right-align the About hero portrait at both mobile and desktop widths while preserving the default left alignment for other hero instances
- round both top corners on every shared background-hero image, including About, Therapy Services, and the individual service pages
- close the mobile navigation dialog and reset the page to the top when a menu link is selected
- remove the empty hero-footer gap and mobile-only bottom padding that created excessive whitespace below shared hero sections

## Root cause

The CTA used the default centered `object-cover` crop for a portrait image inside a square mobile frame. The About hero had no explicit media alignment option, and its desktop media column did not consume the available flexible width. Shared hero rounding was applied only to the overflow frame, so the image corner away from the frame edge remained square. The mobile menu links did not explicitly close their dialog or handle same-route scroll position. The shared hero also rendered an empty footer container, so its `gap-16` combined with hero and following-section padding.

## Validation

- Prettier check on changed files
- focused ESLint on the changed shared components
- `RESEND_API_KEY=re_dummy yarn build`
- Playwright at 390×844 and 1440×1000: About portrait is right-aligned with zero frame-edge delta, other hero instances retain their default left alignment, and no console errors or framework overlays were detected
- Playwright on About and Therapy Services at 390×844 and 1440×1000: both image top corners compute to an 8px radius
- Playwright at 390×844: consultation portrait uses the corrected `50% 20%` focal point; About hero-to-heading gap is 64px; same-route mobile menu selection closes the dialog and returns `scrollY` to 0

## Existing lint debt

A full-file ESLint run on `src/app/about/page.tsx` still reports six pre-existing `react/no-unescaped-entities` errors in page copy; this PR does not alter those lines.