### PR TITLE
Add contact form honeypot

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -6,7 +6,11 @@ const resend = new Resend(process.env.RESEND_API_KEY)
 export async function POST(request: Request) {
   try {
     const body = await request.json()
-    const { fullName, email, description } = body
+    const { fullName, email, description, company } = body
+
+    if (company) {
+      return NextResponse.json({ success: true })
+    }
 
     // Validate required fields
     if (!fullName || !email || !description) {

--- a/src/components/elements/contact-form.tsx
+++ b/src/components/elements/contact-form.tsx
@@ -9,6 +9,7 @@ export function ContactForm() {
   const [fullName, setFullName] = useState('')
   const [email, setEmail] = useState('')
   const [description, setDescription] = useState('')
+  const [company, setCompany] = useState('')
   const [formState, setFormState] = useState<FormState>('idle')
   const [errorMessage, setErrorMessage] = useState('')
 
@@ -21,7 +22,7 @@ export function ContactForm() {
       const response = await fetch('/api/contact', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ fullName, email, description }),
+        body: JSON.stringify({ fullName, email, description, company }),
       })
 
       if (!response.ok) {
@@ -59,6 +60,18 @@ export function ContactForm() {
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <div className="sr-only" aria-hidden="true">
+        <label htmlFor="company">Company</label>
+        <input
+          type="text"
+          id="company"
+          name="company"
+          tabIndex={-1}
+          autoComplete="off"
+          value={company}
+          onChange={(e) => setCompany(e.target.value)}
+        />
+      </div>
       <div className="flex flex-col gap-1.5">
         <label htmlFor="fullName" className="text-sm font-medium text-mist-950">
           Full Name


### PR DESCRIPTION
Adds a visually hidden company field to the active contact form and silently drops any submission that fills it before Resend is called. This protects the live contact endpoint from basic automated form-fillers. Validated with a production build; the focused lint command remains blocked by a pre-existing apostrophe warning in unchanged text.