### PR TITLE
Redirect legacy therapy services URL

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,9 @@ const nextConfig: NextConfig = {
   turbopack: {
     root: __dirname,
   },
+  async redirects() {
+    return [{ source: '/therapy-services', destination: '/services', permanent: true }]
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary
- permanently redirect `/therapy-services` to `/services`

## Root cause
The site route was renamed to `/services`, leaving the indexed legacy URL as a 404.

## Validation
- `yarn build` (Node 24)
- production-mode HTTP check: `/therapy-services` returns 308 to `/services`, which returns 200